### PR TITLE
Add SettleRisk — resolution risk & dispute pricing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Kalshi is a CFTC-regulated exchange where users can trade on event contracts. Th
 - [FinFeedAPI - Prediction Markets](https://finfeed.io/api/prediction-markets) - Unified API for Kalshi, Polymarket, Myriad, and Manifold markets
 - [RapidAPI - Kalshi](https://rapidapi.com/hub?term=kalshi) - Kalshi API available through RapidAPI marketplace
 - [Kalshi Scraper (Apify)](https://apify.com/kalshi-scraper) - Automated data collection tool for Kalshi markets
+- [SettleRisk](https://settlerisk.com) - Resolution risk scoring, dispute pricing, and settlement delay modeling API for prediction markets including Kalshi
 
 ## Infrastructure & Integrations
 


### PR DESCRIPTION
Adds [SettleRisk](https://settlerisk.com) to the Data APIs & Aggregators section under Third-Party Aggregators.

SettleRisk provides resolution risk scoring (0–100), dispute-adjusted pricing, and settlement delay modeling for Kalshi markets. It uses a 15-driver taxonomy to explain *why* a market is risky (ambiguous wording, temporal ambiguity, external dependency, etc.) and outputs actionable trading metrics: risk premium, capital lockup cost, and fair spread in basis points.

- REST + gRPC APIs
- Batch scoring (up to 1,000 markets per call)
- Free tier available, no credit card required
- Live demo at https://settlerisk.com/demo