### PR TITLE
Add pm.wiki — prediction market directory with Kalshi coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Kalshi is a CFTC-regulated exchange where users can trade on event contracts. Th
 
 ### Research Tools
 
+- [pm.wiki](https://pm.wiki/) - Independent prediction market directory covering 350+ tools including Kalshi with side-by-side comparisons, reviews, and a dedicated Kalshi API guide
 - [Good Judgement Open](https://www.gjopen.com/) - Forecasting practice platform with methodology applicable to Kalshi
 - [The Making of a Top Forecaster](https://www.infer-pub.com/blog/top-forecaster-techniques) - Forecasting techniques guide
 


### PR DESCRIPTION
## Add pm.wiki

**[pm.wiki](https://pm.wiki/)** — Independent prediction market directory covering 350+ tools and platforms, including dedicated Kalshi content: a comprehensive Kalshi API guide, Kalshi review, fee comparison, and side-by-side comparisons with other platforms.

Added under Educational Resources > Research Tools.

Free, independent resource.