### PR TITLE
Add PredScope analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Kalshi is a CFTC-regulated exchange where users can trade on event contracts. Th
 - [Polymarket Analytics](https://polymarket-analytics.com/) - Cross-platform analytics including Kalshi market tracking
 - [MetaForecast](https://metaforecast.org/) - Prediction market aggregator including Kalshi markets
 - [FinFeedAPI](https://finfeed.io/api/prediction-markets) - Unified API with Kalshi data alongside other platforms
+- [PredScope](https://predscope.com) - Prediction market analytics platform covering Kalshi markets with reviews, guides, and real-time data
 
 ## API Libraries & SDKs
 


### PR DESCRIPTION
## What is PredScope?

[PredScope](https://predscope.com) is a prediction market analytics platform covering Kalshi markets with reviews, guides, and real-time data. It provides comprehensive market coverage including odds tracking, educational content, and data tools for Kalshi traders and researchers.

## Change

Added PredScope under the **Analytics & Tracking > Dashboards & Analytics** section.