### PR TITLE
Add pmwatch - prediction market anomaly monitor for insider trading detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Kalshi is a CFTC-regulated exchange where users can trade on event contracts. Th
 - [Trading Tools](#trading-tools)
 - [Data APIs & Aggregators](#data-apis--aggregators)
 - [Infrastructure & Integrations](#infrastructure--integrations)
+- [Monitoring & Compliance](#monitoring--compliance)
 - [Educational Resources](#educational-resources)
 - [Community](#community)
 - [Opportunities](#opportunities)
@@ -39,6 +40,10 @@ Kalshi is a CFTC-regulated exchange where users can trade on event contracts. Th
 - [Polymarket Analytics](https://polymarket-analytics.com/) - Cross-platform analytics including Kalshi market tracking
 - [MetaForecast](https://metaforecast.org/) - Prediction market aggregator including Kalshi markets
 - [FinFeedAPI](https://finfeed.io/api/prediction-markets) - Unified API with Kalshi data alongside other platforms
+
+## Monitoring & Compliance
+
+- [pmwatch](https://github.com/lweiss01/pmwatch) - Open-source anomaly detector for politically-sensitive Kalshi markets. Monitors 33 high-MNPI-risk series (cabinet departures, SCOTUS, AG nominations, Fed decisions, geopolitical actions) and flags unusual volume spikes and price divergence that may indicate insider trading.
 
 ## API Libraries & SDKs
 


### PR DESCRIPTION
Adds pmwatch under a new "Monitoring & Compliance" section.

pmwatch is an open-source tool built in response to the George Santos/Kalshi 
insider trading investigation (June 2026). It monitors 33 politically-sensitive 
Kalshi series using only the public API and flags anomalous trading patterns 
that may precede public announcements.

- Repo: https://github.com/lweiss01/pmwatch
- No API key required
- Actively maintained (launched today, scheduler running)
- Includes collector, scorer, FastAPI backend, and live dashboard